### PR TITLE
add GNOME gitlab homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,10 @@ https://github.com/alex-shpak/hugo-book
 <ul>
 <li><a href="https://bugzilla.gnome.org/">https://bugzilla.gnome.org/</a></li>
 </ul>
+<h3 id="gitlab">Gitlab</h3>
+<ul>
+<li><a href="https://gitlab.gnome.org/">https://gitlab.gnome.org/</a></li>
+</ul>
 
   </div>
   


### PR DESCRIPTION
add GNOME gitlab homepage
Almost GNOME projects deal with bugs & issues on  gitlab homepage.

close #2 